### PR TITLE
Estrada_Bootstrap_Header_eliminacion de ul

### DIFF
--- a/tp2_Grupo44/src/main/resources/templates/layouts/header.html
+++ b/tp2_Grupo44/src/main/resources/templates/layouts/header.html
@@ -36,27 +36,15 @@
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                     </button>
-                    <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-                        <ul class="navbar-nav text-center navbar-list">
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/index}" class="list-group-item-action list-group-item-info" >Inicio</a>
-                            </li>
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/productos/listado}" class="list-group-item-action list-group-item-info">Productos</a>
-                            </li>
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/consejos_de_salud/listado}" class="list-group-item-action list-group-item-info">Consejos de Salud</a>
-                            </li>
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/servicio_de_paseos/listado}" class="list-group-item-action list-group-item-info">Servicio de Paseos</a>
-                            </li>
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/sucursales/listado}" class="list-group-item-action list-group-item-info">Sucursales</a>
-                            </li>
-                            <li class="nav-item nav-link">
-                                <a th:href="@{/contactanos}" class="list-group-item-action list-group-item-info">Contáctanos</a>
-                            </li>
-                        </ul>
+                    <div class="collapse navbar-collapse justify-content-end " id="navbarNav">
+                        <div class="navbar-nav text-center navbar-list">
+                            <a th:href="@{/index}" class="nav-link" >Inicio</a>
+                            <a th:href="@{/productos/listado}" class="nav-link">Productos</a>
+                            <a th:href="@{/consejos_de_salud/listado}" class="nav-link">Consejos de Salud</a>
+                            <a th:href="@{/servicio_de_paseos/listado}" class="nav-link">Servicio de Paseos</a>
+                            <a th:href="@{/sucursales/listado}" class="nav-link">Sucursales</a>                          
+                            <a th:href="@{/contactanos}" class="nav-link">Contáctanos</a>
+                        </div>
                     </div>
                 </div>
             </nav>  


### PR DESCRIPTION
se modificaron los items del **nav** reemplazando la etiqueta **ul** y sus respectivos **li** implementando la clase _navbar-nav_ proporcionado por bootstap para simplificar el codigo 
rama en la que se hicieron los cambios: https://github.com/cintiabelenestrada/repo-tp2/tree/branch_CintiaBelenEstrada_Bootstrap_Header