### PR TITLE
Se centró texto de las tablas de servicio de paseos mediante bootstrap

### DIFF
--- a/tp2_Grupo44/src/main/resources/templates/servicio_de_paseos.html
+++ b/tp2_Grupo44/src/main/resources/templates/servicio_de_paseos.html
@@ -50,7 +50,7 @@
                          th:if="${#strings.equals(imagen.identificador, provincia)}"
                          th:src="${imagen.nombre}">
                 </div>
-                <table class="table table-bordered table-striped table-hover">
+                <table class="table table-bordered table-striped table-hover text-center">
                     <thead class="align-middle text-center">
                         <tr>
                             <th scope="col">Nombre</th>


### PR DESCRIPTION
Se centró el texto y botones de las tablas de servicio de paseos mediante bootstrap.